### PR TITLE
can cache obstacle polygons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ categories = ["game-development"]
 itertools = "0.13"
 
 [dependencies.polyanya]
-version = "0.7.0"
+# version = "0.7.0"
+git = "https://github.com/vleue/polyanya"
 
 [dependencies.bevy]
 version = "0.14.0-rc.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ categories = ["game-development"]
 itertools = "0.13"
 
 [dependencies.polyanya]
-# version = "0.7.0"
-git = "https://github.com/vleue/polyanya"
+version = "0.7.1"
 
 [dependencies.bevy]
 version = "0.14.0-rc.4"

--- a/examples/auto_navmesh_aabb.rs
+++ b/examples/auto_navmesh_aabb.rs
@@ -45,7 +45,7 @@ fn main() {
             (
                 setup,
                 ui::setup_stats::<true>,
-                ui::setup_settings,
+                ui::setup_settings::<false>,
                 agent::setup_agent::<10>,
             ),
         )

--- a/examples/auto_navmesh_primitive.rs
+++ b/examples/auto_navmesh_primitive.rs
@@ -41,7 +41,7 @@ fn main() {
             (
                 setup,
                 ui::setup_stats::<true>,
-                ui::setup_settings,
+                ui::setup_settings::<false>,
                 agent::setup_agent::<10>,
             ),
         )

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -39,7 +39,7 @@ fn main() {
             // Obstacles will be entities with the `Obstacle` marker component,
             // and use the `Aabb` component as the obstacle data source.
             // NavmeshUpdaterPlugin::<Obstacle, Aabb>::default(),
-            NavmeshUpdaterPlugin::<PrimitiveObstacle>::default(),
+            NavmeshUpdaterPlugin::<CachedObstacle<PrimitiveObstacle>>::default(),
         ))
         .add_systems(
             Startup,
@@ -54,7 +54,7 @@ fn main() {
             Update,
             (
                 display_mesh,
-                ui::update_stats::<PrimitiveObstacle>,
+                ui::update_stats::<CachedObstacle<PrimitiveObstacle>>,
                 remove_obstacles,
                 ui::display_settings,
                 ui::update_settings::<10>,
@@ -78,9 +78,14 @@ struct Lifetime(Timer);
 fn life_of_obstacle(
     mut commands: Commands,
     time: Res<Time>,
-    mut obstacles: Query<(Entity, &mut Lifetime, &mut Transform)>,
+    mut obstacles: Query<(
+        Entity,
+        &mut Lifetime,
+        &mut Transform,
+        &mut CachedObstacle<PrimitiveObstacle>,
+    )>,
 ) {
-    for (entity, mut lifetime, mut transform) in obstacles.iter_mut() {
+    for (entity, mut lifetime, mut transform, mut cached) in obstacles.iter_mut() {
         lifetime.0.tick(time.delta());
         if lifetime.0.fraction() < 0.2 {
             transform.scale = Vec3::new(
@@ -88,6 +93,7 @@ fn life_of_obstacle(
                 1.0,
                 lifetime.0.fraction() * 5.0,
             );
+            cached.clear();
         }
         if lifetime.0.fraction() > 0.8 {
             transform.scale = Vec3::new(
@@ -95,6 +101,7 @@ fn life_of_obstacle(
                 1.0,
                 (-lifetime.0.fraction() + 1.0) * 5.0 + 0.01,
             );
+            cached.clear();
         }
         if lifetime.0.finished() {
             commands.entity(entity).despawn_recursive();
@@ -218,7 +225,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    PrimitiveObstacle::Rectangle(larger_primitive),
+                    CachedObstacle::new(PrimitiveObstacle::Rectangle(larger_primitive)),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -244,7 +251,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    PrimitiveObstacle::Circle(larger_primitive),
+                    CachedObstacle::new(PrimitiveObstacle::Circle(larger_primitive)),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -270,7 +277,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    PrimitiveObstacle::Ellipse(larger_primitive),
+                    CachedObstacle::new(PrimitiveObstacle::Ellipse(larger_primitive)),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -293,7 +300,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    PrimitiveObstacle::Capsule(larger_primitive),
+                    CachedObstacle::new(PrimitiveObstacle::Capsule(larger_primitive)),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -316,7 +323,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    PrimitiveObstacle::RegularPolygon(larger_primitive),
+                    CachedObstacle::new(PrimitiveObstacle::RegularPolygon(larger_primitive)),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -341,7 +348,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    PrimitiveObstacle::Rhombus(larger_primitive),
+                    CachedObstacle::new(PrimitiveObstacle::Rhombus(larger_primitive)),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -35,10 +35,6 @@ fn main() {
                 ..default()
             }),
             VleueNavigatorPlugin,
-            // Auto update the navmesh.
-            // Obstacles will be entities with the `Obstacle` marker component,
-            // and use the `Aabb` component as the obstacle data source.
-            // NavmeshUpdaterPlugin::<Obstacle, Aabb>::default(),
             NavmeshUpdaterPlugin::<CachedObstacle<PrimitiveObstacle>>::default(),
         ))
         .add_systems(

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -35,7 +35,7 @@ fn main() {
                 ..default()
             }),
             VleueNavigatorPlugin,
-            NavmeshUpdaterPlugin::<CachedObstacle<PrimitiveObstacle>>::default(),
+            NavmeshUpdaterPlugin::<PrimitiveObstacle>::default(),
         ))
         .add_systems(
             Startup,
@@ -50,7 +50,7 @@ fn main() {
             Update,
             (
                 display_mesh,
-                ui::update_stats::<CachedObstacle<PrimitiveObstacle>>,
+                ui::update_stats::<PrimitiveObstacle>,
                 remove_obstacles,
                 ui::display_settings,
                 ui::update_settings::<10>,
@@ -74,14 +74,9 @@ struct Lifetime(Timer);
 fn life_of_obstacle(
     mut commands: Commands,
     time: Res<Time>,
-    mut obstacles: Query<(
-        Entity,
-        &mut Lifetime,
-        &mut Transform,
-        &mut CachedObstacle<PrimitiveObstacle>,
-    )>,
+    mut obstacles: Query<(Entity, &mut Lifetime, &mut Transform)>,
 ) {
-    for (entity, mut lifetime, mut transform, mut cached) in obstacles.iter_mut() {
+    for (entity, mut lifetime, mut transform) in obstacles.iter_mut() {
         lifetime.0.tick(time.delta());
         if lifetime.0.fraction() < 0.2 {
             transform.scale = Vec3::new(
@@ -89,7 +84,6 @@ fn life_of_obstacle(
                 1.0,
                 lifetime.0.fraction() * 5.0,
             );
-            cached.clear();
         }
         if lifetime.0.fraction() > 0.8 {
             transform.scale = Vec3::new(
@@ -97,7 +91,6 @@ fn life_of_obstacle(
                 1.0,
                 (-lifetime.0.fraction() + 1.0) * 5.0 + 0.01,
             );
-            cached.clear();
         }
         if lifetime.0.finished() {
             commands.entity(entity).despawn_recursive();
@@ -221,7 +214,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    CachedObstacle::new(PrimitiveObstacle::Rectangle(larger_primitive)),
+                    PrimitiveObstacle::Rectangle(larger_primitive),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -247,7 +240,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    CachedObstacle::new(PrimitiveObstacle::Circle(larger_primitive)),
+                    PrimitiveObstacle::Circle(larger_primitive),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -273,7 +266,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    CachedObstacle::new(PrimitiveObstacle::Ellipse(larger_primitive)),
+                    PrimitiveObstacle::Ellipse(larger_primitive),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -296,7 +289,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    CachedObstacle::new(PrimitiveObstacle::Capsule(larger_primitive)),
+                    PrimitiveObstacle::Capsule(larger_primitive),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -319,7 +312,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    CachedObstacle::new(PrimitiveObstacle::RegularPolygon(larger_primitive)),
+                    PrimitiveObstacle::RegularPolygon(larger_primitive),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,
@@ -344,7 +337,7 @@ fn new_obstacle(
                 .spawn((
                     transform,
                     GlobalTransform::default(),
-                    CachedObstacle::new(PrimitiveObstacle::Rhombus(larger_primitive)),
+                    PrimitiveObstacle::Rhombus(larger_primitive),
                     Lifetime(Timer::from_seconds(
                         rng.gen_range(20.0..40.0),
                         TimerMode::Once,

--- a/examples/helpers/ui.rs
+++ b/examples/helpers/ui.rs
@@ -5,6 +5,7 @@ use vleue_navigator::prelude::*;
 pub enum UiSettings {
     Simplify,
     MergeSteps,
+    Cache,
 }
 
 #[derive(Component)]
@@ -13,6 +14,12 @@ pub enum UiSettingsButtons {
     SimplifyDec,
     MergeStepsInc,
     MergeStepsDec,
+    ToggleCache,
+}
+
+#[derive(Resource, Default)]
+pub struct ExampleSettings {
+    pub cache_enabled: bool,
 }
 
 fn button(text: &str, action: UiSettingsButtons, parent: &mut ChildBuilder) {
@@ -29,7 +36,7 @@ fn button(text: &str, action: UiSettingsButtons, parent: &mut ChildBuilder) {
                 },
                 border_color: BorderColor(palettes::tailwind::GRAY_500.into()),
                 border_radius: BorderRadius::MAX,
-                image: UiImage::default().with_color(palettes::tailwind::GRAY_700.into()),
+                background_color: palettes::tailwind::GRAY_700.into(),
                 ..default()
             },
             action,
@@ -45,7 +52,8 @@ fn button(text: &str, action: UiSettingsButtons, parent: &mut ChildBuilder) {
         });
 }
 
-pub fn setup_settings(mut commands: Commands) {
+pub fn setup_settings<const WITH_CACHE: bool>(mut commands: Commands) {
+    commands.init_resource::<ExampleSettings>();
     commands
         .spawn((
             NodeBundle {
@@ -129,12 +137,45 @@ pub fn setup_settings(mut commands: Commands) {
                     button(" - ", UiSettingsButtons::MergeStepsDec, parent);
                     button(" + ", UiSettingsButtons::MergeStepsInc, parent);
                 });
+            if WITH_CACHE {
+                parent
+                    .spawn((
+                        ButtonBundle {
+                            style: Style {
+                                margin: UiRect::px(30.0, 30.0, 10.0, 30.0),
+                                border: UiRect::all(Val::Px(1.0)),
+                                justify_content: JustifyContent::Center,
+                                height: Val::Px(30.0),
+                                align_items: AlignItems::Center,
+                                ..default()
+                            },
+                            border_color: BorderColor(palettes::tailwind::GRAY_500.into()),
+                            border_radius: BorderRadius::all(Val::Px(10.0)),
+                            image: UiImage::default()
+                                .with_color(palettes::tailwind::GRAY_700.into()),
+                            ..default()
+                        },
+                        UiSettingsButtons::ToggleCache,
+                        UiSettings::Cache,
+                    ))
+                    .with_children(|parent| {
+                        parent.spawn(TextBundle::from_section(
+                            "Cache",
+                            TextStyle {
+                                font_size: 20.0,
+                                ..default()
+                            },
+                        ));
+                    });
+            }
         });
 }
 
 pub fn display_settings(
     settings: Query<Ref<NavMeshSettings>>,
+    example_settings: Res<ExampleSettings>,
     mut texts: Query<(&mut Text, &UiSettings)>,
+    mut buttons: Query<(&mut BackgroundColor, &UiSettings), With<Button>>,
 ) {
     let settings = settings.single();
     if settings.is_changed() {
@@ -146,6 +187,22 @@ pub fn display_settings(
                 UiSettings::MergeSteps => {
                     text.sections[1].value = format!("{}", settings.merge_steps)
                 }
+                UiSettings::Cache => (),
+            }
+        }
+    }
+    if example_settings.is_changed() {
+        for (mut color, param) in &mut buttons {
+            match param {
+                UiSettings::Simplify => (),
+                UiSettings::MergeSteps => (),
+                UiSettings::Cache => {
+                    *color = if example_settings.cache_enabled {
+                        palettes::tailwind::GREEN_400.into()
+                    } else {
+                        palettes::tailwind::RED_600.into()
+                    }
+                }
             }
         }
     }
@@ -153,12 +210,13 @@ pub fn display_settings(
 
 pub fn update_settings<const STEP: u32>(
     mut interaction_query: Query<
-        (&Interaction, &UiSettingsButtons, &mut UiImage),
+        (&Interaction, &UiSettingsButtons, &mut BackgroundColor),
         (Changed<Interaction>, With<Button>),
     >,
     mut settings: Query<&mut NavMeshSettings>,
+    mut example_settings: ResMut<ExampleSettings>,
 ) {
-    for (interaction, button, mut image) in &mut interaction_query {
+    for (interaction, button, mut color) in &mut interaction_query {
         match *interaction {
             Interaction::Pressed => {
                 let mut settings = settings.single_mut();
@@ -167,7 +225,7 @@ pub fn update_settings<const STEP: u32>(
                         settings.simplify = (settings.simplify - STEP as f32 / 1000.0).max(0.0);
                     }
                     UiSettingsButtons::SimplifyInc => {
-                        settings.simplify = (settings.simplify + STEP as f32 / 1000.0).min(0.5);
+                        settings.simplify = (settings.simplify + STEP as f32 / 1000.0).min(10.0);
                     }
                     UiSettingsButtons::MergeStepsDec => {
                         settings.merge_steps = settings.merge_steps.checked_sub(1).unwrap_or(0);
@@ -175,13 +233,20 @@ pub fn update_settings<const STEP: u32>(
                     UiSettingsButtons::MergeStepsInc => {
                         settings.merge_steps = (settings.merge_steps + 1).min(5);
                     }
+                    UiSettingsButtons::ToggleCache => {
+                        example_settings.cache_enabled = !example_settings.cache_enabled;
+                    }
                 }
             }
             Interaction::Hovered => {
-                image.color = palettes::tailwind::GRAY_600.into();
+                if !matches!(button, UiSettingsButtons::ToggleCache) {
+                    *color = palettes::tailwind::GRAY_600.into();
+                }
             }
             Interaction::None => {
-                image.color = palettes::tailwind::GRAY_700.into();
+                if !matches!(button, UiSettingsButtons::ToggleCache) {
+                    *color = palettes::tailwind::GRAY_700.into();
+                }
             }
         }
     }
@@ -270,6 +335,7 @@ pub fn update_stats<T: Component>(
         NavMeshStatus::Building => palettes::tailwind::AMBER_500.into(),
         NavMeshStatus::Built => palettes::tailwind::GREEN_400.into(),
         NavMeshStatus::Failed => palettes::tailwind::RED_600.into(),
+        NavMeshStatus::Cancelled => palettes::tailwind::AMBER_500.into(),
     };
     text.sections[3].value = format!("{}", obstacles.iter().len());
     text.sections[5].value = format!(

--- a/examples/helpers/ui.rs
+++ b/examples/helpers/ui.rs
@@ -1,4 +1,4 @@
-use bevy::{color::palettes, prelude::*};
+use bevy::{color::palettes, diagnostic::DiagnosticsStore, prelude::*};
 use vleue_navigator::prelude::*;
 
 #[derive(Component)]
@@ -219,6 +219,9 @@ pub fn setup_stats<const INTERACTIVE: bool>(mut commands: Commands) {
                 ("{}", 30.0),
                 ("\nPolygons: ", 30.0),
                 ("{}", 30.0),
+                ("\nBuild Duration: ", 30.0),
+                ("{}", 30.0),
+                ("ms", 30.0),
             ];
             if INTERACTIVE {
                 text.push(("\n\nClick to add an obstacle", 25.0));
@@ -253,6 +256,7 @@ pub fn update_stats<T: Component>(
     obstacles: Query<&T>,
     navmesh: Query<(Ref<NavMeshStatus>, &Handle<NavMesh>)>,
     navmeshes: Res<Assets<NavMesh>>,
+    diagnostics: Res<DiagnosticsStore>,
 ) {
     let (status, handle) = navmesh.single();
 
@@ -274,6 +278,15 @@ pub fn update_stats<T: Component>(
             .get(handle)
             .map(|nm| nm.get().polygons.len())
             .unwrap_or_default()
+    );
+    text.sections[7].value = format!(
+        "{:.3}",
+        diagnostics
+            .get(&NAVMESH_BUILD_DURATION)
+            .unwrap()
+            .smoothed()
+            .unwrap_or_default()
+            * 1000.0
     );
 }
 

--- a/examples/primitive_3d.rs
+++ b/examples/primitive_3d.rs
@@ -36,7 +36,7 @@ fn main() {
             (
                 setup,
                 ui::setup_stats::<true>,
-                ui::setup_settings,
+                ui::setup_settings::<false>,
                 agent2d::setup_agent::<100>,
             ),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,9 @@ mod updater;
 
 /// Prelude for imports
 pub mod prelude {
-    pub use crate::obstacles::{primitive::PrimitiveObstacle, ObstacleSource};
+    pub use crate::obstacles::{
+        cached::CachedObstacle, primitive::PrimitiveObstacle, ObstacleSource,
+    };
     pub use crate::updater::{
         NavMeshBundle, NavMeshSettings, NavMeshStatus, NavMeshUpdateMode, NavmeshUpdaterPlugin,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,9 +129,7 @@ impl NavMesh {
     /// Depending on the scale of your mesh, you should change the [`delta`](polyanya::Mesh::delta) value using [`set_delta`].
     pub fn from_edge_and_obstacles(edges: Vec<Vec2>, obstacles: Vec<Vec<Vec2>>) -> NavMesh {
         let mut triangulation = Triangulation::from_outer_edges(&edges);
-        for obstacle in obstacles {
-            triangulation.add_obstacle(obstacle);
-        }
+        triangulation.add_obstacles(obstacles);
 
         let mut mesh: polyanya::Mesh = triangulation.as_navmesh();
         triangulation.simplify(0.001);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@ pub mod prelude {
         cached::CachedObstacle, primitive::PrimitiveObstacle, ObstacleSource,
     };
     pub use crate::updater::{
-        NavMeshBundle, NavMeshSettings, NavMeshStatus, NavMeshUpdateMode, NavmeshUpdaterPlugin,
-        NAVMESH_BUILD_DURATION,
+        CachableObstacle, NavMeshBundle, NavMeshSettings, NavMeshStatus, NavMeshUpdateMode,
+        NavmeshUpdaterPlugin, NAVMESH_BUILD_DURATION,
     };
     pub use crate::{NavMesh, VleueNavigatorPlugin};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod prelude {
     };
     pub use crate::updater::{
         NavMeshBundle, NavMeshSettings, NavMeshStatus, NavMeshUpdateMode, NavmeshUpdaterPlugin,
+        NAVMESH_BUILD_DURATION,
     };
     pub use crate::{NavMesh, VleueNavigatorPlugin};
 }

--- a/src/obstacles/cached.rs
+++ b/src/obstacles/cached.rs
@@ -1,0 +1,48 @@
+use std::sync::{Arc, RwLock};
+
+use bevy::{
+    math::Vec2,
+    prelude::Component,
+    transform::components::{GlobalTransform, Transform},
+};
+
+use super::ObstacleSource;
+
+/// An obstacle source that will cache the polygon from its source obstacle, so that it doesn't need to
+/// be recomputed every time. To clear the cache, you can use [`clear`](CachedObstacle::clear).
+#[derive(Clone, Component, Debug)]
+pub struct CachedObstacle<T: ObstacleSource> {
+    polygon: Arc<RwLock<Option<Vec<Vec2>>>>,
+    source: T,
+}
+
+impl<T: ObstacleSource> CachedObstacle<T> {
+    /// Create a new cached obstacle from another obstacle source
+    pub fn new(source: T) -> Self {
+        Self {
+            polygon: Arc::new(RwLock::new(None)),
+            source,
+        }
+    }
+
+    /// Clear the cache for this obstacle
+    pub fn clear(&mut self) {
+        self.polygon = Arc::new(RwLock::new(None));
+    }
+}
+
+impl<T: ObstacleSource> ObstacleSource for CachedObstacle<T> {
+    fn get_polygon(
+        &self,
+        obstacle_transform: &GlobalTransform,
+        navmesh_transform: &Transform,
+    ) -> Vec<Vec2> {
+        if let Some(poly) = self.polygon.read().unwrap().as_ref() {
+            return poly.clone();
+        }
+        let poly = T::get_polygon(&self.source, obstacle_transform, navmesh_transform);
+        let mut writer = self.polygon.write().unwrap();
+        *writer = Some(poly.clone());
+        poly
+    }
+}

--- a/src/obstacles/mod.rs
+++ b/src/obstacles/mod.rs
@@ -5,6 +5,7 @@ use bevy::{
 };
 
 mod aabb;
+pub(crate) mod cached;
 pub(crate) mod primitive;
 
 /// Trait to mark a component as the source of position and shape of an obstacle.

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -198,16 +198,28 @@ type NavMeshToUpdateQuery<'world, 'state, 'a, 'b, 'c, 'd, 'e, 'f> = Query<
     ),
 >;
 
-fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
-    mut commands: Commands,
-    dynamic_obstacles: Query<
-        (Ref<GlobalTransform>, &Obstacle),
+type ObstacleQueries<'world, 'state, 'a, 'b, 'c, Obstacle, Marker> = (
+    Query<
+        'world,
+        'state,
+        (Ref<'a, GlobalTransform>, &'b Obstacle),
         (With<Marker>, Without<CachableObstacle>),
     >,
-    cachable_obstacles: Query<
-        (Ref<GlobalTransform>, &Obstacle, Ref<CachableObstacle>),
+    Query<
+        'world,
+        'state,
+        (
+            Ref<'a, GlobalTransform>,
+            &'b Obstacle,
+            Ref<'c, CachableObstacle>,
+        ),
         With<Marker>,
     >,
+);
+
+fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
+    mut commands: Commands,
+    (dynamic_obstacles, cachable_obstacles): ObstacleQueries<Obstacle, Marker>,
     removed_obstacles: RemovedComponents<Marker>,
     removed_cachable_obstacles: RemovedComponents<CachableObstacle>,
     mut navmeshes: NavMeshToUpdateQuery,

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -18,6 +18,10 @@ use polyanya::Triangulation;
 
 use crate::{obstacles::ObstacleSource, NavMesh};
 
+/// An obstacle that won't change and can be cached
+#[derive(Component, Clone, Copy, Debug)]
+pub struct CachableObstacle;
+
 /// Bundle for preparing an auto updated navmesh. To use with plugin [`NavmeshUpdaterPlugin`].
 #[derive(Bundle, Debug)]
 pub struct NavMeshBundle {
@@ -58,6 +62,8 @@ pub struct NavMeshSettings {
     pub fixed: Triangulation,
     /// Duration in seconds after which to cancel a navmesh build
     pub build_timeout: Option<f32>,
+    /// Cache from the last build from obstacles that are [`CachableObstacle`]
+    pub cached: Option<Triangulation>,
 }
 
 impl Default for NavMeshSettings {
@@ -68,6 +74,7 @@ impl Default for NavMeshSettings {
             default_delta: 0.01,
             fixed: Triangulation::from_outer_edges(&[]),
             build_timeout: None,
+            cached: None,
         }
     }
 }
@@ -104,15 +111,30 @@ pub struct NavMeshUpdateModeBlocking;
 #[cfg_attr(feature = "tracing", instrument(skip_all))]
 fn build_navmesh<T: ObstacleSource>(
     obstacles: Vec<(GlobalTransform, T)>,
+    cached_obstacles: Vec<(GlobalTransform, T)>,
     settings: NavMeshSettings,
     mesh_transform: Transform,
-) -> NavMesh {
+) -> (Triangulation, NavMesh) {
+    let base = if settings.cached.is_none() {
+        let mut base = settings.fixed;
+        let obstacle_aabbs = cached_obstacles
+            .iter()
+            .map(|(transform, obstacle)| obstacle.get_polygon(transform, &mesh_transform));
+        base.add_obstacles(obstacle_aabbs);
+        if settings.simplify != 0.0 {
+            base.simplify(settings.simplify);
+        }
+        base.prebuild();
+        base
+    } else {
+        settings.cached.unwrap()
+    };
+    let mut triangulation = base.clone();
     let obstacle_aabbs = obstacles
         .iter()
-        .map(|(transform, obstacle)| obstacle.get_polygon(transform, &mesh_transform))
-        .filter(|polygon| !polygon.is_empty());
-    let mut triangulation = settings.fixed.clone();
+        .map(|(transform, obstacle)| obstacle.get_polygon(transform, &mesh_transform));
     triangulation.add_obstacles(obstacle_aabbs);
+
     if settings.simplify != 0.0 {
         triangulation.simplify(settings.simplify);
     }
@@ -126,7 +148,7 @@ fn build_navmesh<T: ObstacleSource>(
     navmesh.set_delta(settings.default_delta);
     let mut navmesh = NavMesh::from_polyanya_mesh(navmesh);
     navmesh.set_transform(mesh_transform);
-    navmesh
+    (base, navmesh)
 }
 
 fn drop_dead_tasks(
@@ -153,15 +175,21 @@ fn drop_dead_tasks(
 }
 
 /// Task holder for a navmesh update.
-#[derive(Component, Debug, Clone)]
-pub struct NavmeshUpdateTask(Arc<RwLock<Option<(NavMesh, Duration)>>>);
+#[derive(Component, Clone)]
+pub struct NavmeshUpdateTask(Arc<RwLock<Option<TaskResult>>>);
+
+struct TaskResult {
+    navmesh: NavMesh,
+    duration: Duration,
+    to_cache: Triangulation,
+}
 
 type NavMeshToUpdateQuery<'world, 'state, 'a, 'b, 'c, 'd, 'e, 'f> = Query<
     'world,
     'state,
     (
         Entity,
-        Ref<'a, NavMeshSettings>,
+        &'a mut NavMeshSettings,
         Ref<'b, Transform>,
         &'c NavMeshUpdateMode,
         &'d mut NavMeshStatus,
@@ -172,8 +200,16 @@ type NavMeshToUpdateQuery<'world, 'state, 'a, 'b, 'c, 'd, 'e, 'f> = Query<
 
 fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
     mut commands: Commands,
-    obstacles: Query<(Ref<GlobalTransform>, &Obstacle), With<Marker>>,
+    dynamic_obstacles: Query<
+        (Ref<GlobalTransform>, &Obstacle),
+        (With<Marker>, Without<CachableObstacle>),
+    >,
+    cachable_obstacles: Query<
+        (Ref<GlobalTransform>, &Obstacle, Ref<CachableObstacle>),
+        With<Marker>,
+    >,
     removed_obstacles: RemovedComponents<Marker>,
+    removed_cachable_obstacles: RemovedComponents<CachableObstacle>,
     mut navmeshes: NavMeshToUpdateQuery,
     time: Res<Time>,
     mut ready_to_update: Local<HashMap<Entity, (f32, bool)>>,
@@ -190,16 +226,25 @@ fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
             ready_to_update.remove(&key);
         }
     }
+    if !removed_cachable_obstacles.is_empty()
+        || cachable_obstacles.iter().any(|(_, _, c)| c.is_added())
+    {
+        for (_, mut settings, ..) in &mut navmeshes {
+            info!("clear cache");
+            settings.cached = None;
+        }
+    }
+
     let has_removed_obstacles = !removed_obstacles.is_empty();
     let mut to_check = navmeshes
-        .iter()
+        .iter_mut()
         .filter_map(|(entity, settings, _, mode, ..)| {
-            if obstacles
-                .iter()
-                .any(|(t, _)| t.is_changed() && !t.is_added())
-                || settings.is_changed()
+            if settings.is_changed()
                 || has_removed_obstacles
                 || matches!(mode, NavMeshUpdateMode::OnDemand(true))
+                || dynamic_obstacles
+                    .iter()
+                    .any(|(t, _)| t.is_changed() && !t.is_added())
             {
                 Some(entity)
             } else {
@@ -235,7 +280,15 @@ fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
             if updating.is_some() {
                 continue;
             }
-            let obstacles_local = obstacles
+            let cached_obstacles = if settings.cached.is_none() {
+                cachable_obstacles
+                    .iter()
+                    .map(|(t, o, _)| (*t, o.clone()))
+                    .collect::<Vec<_>>()
+            } else {
+                vec![]
+            };
+            let obstacles_local = dynamic_obstacles
                 .iter()
                 .map(|(t, o)| (*t, o.clone()))
                 .collect::<Vec<_>>();
@@ -247,15 +300,32 @@ fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
             let writer = updating.0.clone();
             if is_blocking.is_some() {
                 let start = bevy::utils::Instant::now();
-                let navmesh = build_navmesh(obstacles_local, settings_local, transform_local);
-                *writer.write().unwrap() = Some((navmesh, start.elapsed()));
+                let (to_cache, navmesh) = build_navmesh(
+                    obstacles_local,
+                    cached_obstacles,
+                    settings_local,
+                    transform_local,
+                );
+                *writer.write().unwrap() = Some(TaskResult {
+                    navmesh,
+                    duration: start.elapsed(),
+                    to_cache,
+                });
             } else {
                 AsyncComputeTaskPool::get()
                     .spawn(async move {
                         let start = bevy::utils::Instant::now();
-                        let navmesh =
-                            build_navmesh(obstacles_local, settings_local, transform_local);
-                        *writer.write().unwrap() = Some((navmesh, start.elapsed()));
+                        let (to_cache, navmesh) = build_navmesh(
+                            obstacles_local,
+                            cached_obstacles,
+                            settings_local,
+                            transform_local,
+                        );
+                        *writer.write().unwrap() = Some(TaskResult {
+                            navmesh,
+                            duration: start.elapsed(),
+                            to_cache,
+                        });
                     })
                     .detach();
             }
@@ -271,18 +341,24 @@ fn update_navmesh_asset(
         &Handle<NavMesh>,
         &NavmeshUpdateTask,
         &mut NavMeshStatus,
+        &mut NavMeshSettings,
     )>,
     mut navmeshes: ResMut<Assets<NavMesh>>,
     mut diagnostics: Diagnostics,
 ) {
-    for (entity, handle, task, mut status) in &mut live_navmeshes {
+    for (entity, handle, task, mut status, mut settings) in &mut live_navmeshes {
         let mut task = task.0.write().unwrap();
         if task.is_some() {
-            let (navmesh_built, duration) = task.take().unwrap();
+            let TaskResult {
+                navmesh,
+                duration,
+                to_cache,
+            } = task.take().unwrap();
             commands.entity(entity).remove::<NavmeshUpdateTask>();
+            settings.cached = Some(to_cache);
 
             debug!("navmesh built");
-            navmeshes.insert(handle, navmesh_built);
+            navmeshes.insert(handle, navmesh);
             *status = NavMeshStatus::Built;
             diagnostics.add_measurement(&NAVMESH_BUILD_DURATION, || duration.as_secs_f64());
         }
@@ -320,6 +396,6 @@ impl<Obstacle: ObstacleSource, Marker: Component> Plugin
         app.add_systems(PostUpdate, trigger_navmesh_build::<Marker, Obstacle>)
             .add_systems(PreUpdate, update_navmesh_asset)
             .add_systems(Update, drop_dead_tasks)
-            .register_diagnostic(Diagnostic::new(NAVMESH_BUILD_DURATION).with_suffix("s"));
+            .register_diagnostic(Diagnostic::new(NAVMESH_BUILD_DURATION));
     }
 }


### PR DESCRIPTION
two options:
- new obstacle source `CachedObstacle<T>` that takes another obstacle source and will cache its polygon. This can be useful if polygon computation is expensive
- new component `CachableObstacle` that serves as a marker component for obstacles that won't change and can be cached in a partial navmesh (possible with https://github.com/vleue/polyanya/commit/1b019f6be9df741e656441929414a2b4678a31ac)