### PR TITLE
Default values for navmesh settings

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -80,7 +80,9 @@ pub struct NavMeshSettings {
     pub build_timeout: Option<f32>,
     /// Cache from the last build from obstacles that are [`CachableObstacle`]
     pub cached: Option<Triangulation>,
-    /// Upward shift to sample obstacle from the ground
+    /// Upward shift to sample obstacles from the ground
+    ///
+    /// It should be greater than `0.0` in 3d as colliders lying flat on a surface are not considered intersecting. Default value is `0.1`.
     pub upward_shift: f32,
     /// Specific layer to update. If none, the first layer will be updated.
     pub layer: Option<u8>,

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -103,7 +103,8 @@ impl Default for NavMeshSettings {
             fixed: Triangulation::from_outer_edges(&[]),
             build_timeout: None,
             cached: None,
-            upward_shift: 0.0,
+            // Value is arbitrary, but shouldn't be 0.0. colliders lying flat on a surface are not considered as intersecting with 0.0
+            upward_shift: 0.1,
             layer: None,
             stitches: vec![],
             scale: Vec2::ONE,

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -100,7 +100,7 @@ impl Default for NavMeshSettings {
     fn default() -> Self {
         Self {
             simplify: 0.0,
-            merge_steps: 2,
+            merge_steps: 0,
             default_delta: 0.01,
             fixed: Triangulation::from_outer_edges(&[]),
             build_timeout: None,


### PR DESCRIPTION
* use a non 0.0 default upward shift
* use 0 as merge steps

Fixes part of #55 