### PR TITLE
Add `NavMeshSettings::ignore_obstacles`

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 
 use bevy::{
     diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic},
-    ecs::entity::EntityHashMap,
+    ecs::entity::{EntityHashMap, EntityHashSet},
     prelude::*,
     tasks::AsyncComputeTaskPool,
     transform::TransformSystem,
@@ -112,6 +112,8 @@ pub struct NavMeshSettings {
     ///
     /// When using layers, applying the agent radius to outer edges can block stitching them together.
     pub agent_radius_on_outer_edge: bool,
+    /// A set of obstacle entities that should be ignored when building the [`NavMesh`].
+    pub ignore_obstacles: EntityHashSet,
 }
 
 impl Default for NavMeshSettings {
@@ -131,6 +133,7 @@ impl Default for NavMeshSettings {
             scale: Vec2::ONE,
             agent_radius: 0.0,
             agent_radius_on_outer_edge: false,
+            ignore_obstacles: EntityHashSet::default(),
         }
     }
 }
@@ -306,13 +309,13 @@ type ObstacleQueries<'world, 'state, 'a, 'b, 'c, Obstacle, Marker> = (
     Query<
         'world,
         'state,
-        (Ref<'a, GlobalTransform>, Ref<'b, Obstacle>),
+        (Entity, Ref<'a, GlobalTransform>, Ref<'b, Obstacle>),
         (With<Marker>, Without<CachableObstacle>),
     >,
     Query<
         'world,
         'state,
-        (&'a GlobalTransform, &'b Obstacle, Ref<'c, CachableObstacle>),
+        (Entity, &'a GlobalTransform, &'b Obstacle, Ref<'c, CachableObstacle>),
         With<Marker>,
     >,
 );
@@ -339,7 +342,7 @@ fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
         }
     }
     if !removed_cachable_obstacles.is_empty()
-        || cachable_obstacles.iter().any(|(_, _, c)| c.is_added())
+        || cachable_obstacles.iter().any(|(_, _, _, c)| c.is_added())
     {
         for (_, mut settings, ..) in &mut navmeshes {
             debug!("cache cleared due to cachable obstacle change");
@@ -362,7 +365,7 @@ fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
                 || matches!(mode, NavMeshUpdateMode::OnDemand(true))
                 || dynamic_obstacles
                     .iter()
-                    .any(|(t, o)| t.is_changed() || o.is_changed())
+                    .any(|(_, t, o)| t.is_changed() || o.is_changed())
             {
                 Some(entity)
             } else {
@@ -408,14 +411,14 @@ fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
             let cached_obstacles = if settings.cached.is_none() {
                 cachable_obstacles
                     .iter()
-                    .map(|(t, o, _)| (*t, o.clone()))
+                    .filter_map(|(e, t, o, _)| (!settings.ignore_obstacles.contains(&e)).then_some((*t, o.clone())))
                     .collect::<Vec<_>>()
             } else {
                 vec![]
             };
             let obstacles_local = dynamic_obstacles
                 .iter()
-                .map(|(t, o)| (*t, o.clone()))
+                .filter_map(|(e, t, o)| (!settings.ignore_obstacles.contains(&e)).then_some((*t, o.clone())))
                 .collect::<Vec<_>>();
             let settings_local = settings.clone();
             let transform_local = global_transform.compute_transform();


### PR DESCRIPTION
Hello!

I have a use case to dynamically exclude specific obstacles from specific Nav Meshes. Based on my research, there is currently no way to do this with given API, so I decided to add it.

This CL just adds an `ignore_obstacles` entity set. When building the Nav Mesh, we just filter out these entities from the obstacles.

Let me know if anything is missing, please!