### PR TITLE
chore: release v0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vleue_navigator"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["François Mockers <francois.mockers@vleue.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `vleue_navigator`: 0.12.0 -> 0.12.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).